### PR TITLE
Agregado un folder argumento para library driver

### DIFF
--- a/lantz/core/foreign.py
+++ b/lantz/core/foreign.py
@@ -225,9 +225,9 @@ class LibraryDriver(Driver):
 
     def __init__(self, *args, **kwargs):
         library_name = kwargs.pop('library_name', None)
+        folder = kwargs.pop('library_folder', os.path.dirname(inspect.getfile(self.__class__)))
         super().__init__(*args, **kwargs)
 
-        folder = os.path.dirname(inspect.getfile(self.__class__))
         for name in chain(iter_lib(library_name, folder), iter_lib(self.LIBRARY_NAME, folder)):
             if name is None:
                 continue


### PR DESCRIPTION
Este argumento es util en los casos donde uno utiliza wrap_driver_cls para usar el driver en una aplicacion de qt, ya que el metedo getfile() devolveria el archivo de lantz y no el usado para el driver.