### PR TITLE
Use get_application_registry() for Q_ definition

### DIFF
--- a/lantz/core/__init__.py
+++ b/lantz/core/__init__.py
@@ -20,8 +20,8 @@ try:
 except:
     __version__ = "unknown"
 
-from pint import UnitRegistry
-ureg = UnitRegistry()
+from pint import get_application_registry
+ureg = get_application_registry()
 Q_ = ureg.Quantity
 
 from serialize import register_class


### PR DESCRIPTION
If the user already has a pint unit registry in their application they likely want Lantz to use the existing registry rather than creating a new one.